### PR TITLE
Scout puppet run plugin fix

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -67,11 +67,9 @@ class scout(
     mode   => '0755',
   }
 
-  ensure_resource('user', $user,
-    {
-      'ensure'     => 'present',
-      'managehome' => true,
-      'home'       => $valid_home_dir
-    }
-  )
+  user { $user:
+    ensure     => 'present',
+    managehome => true,
+    home       => $valid_home_dir,
+  }
 }


### PR DESCRIPTION
We commonly use the scout puppet last run plugin on our hosts, but the
default perms for a puppet install prevent it from running.  This opens
them up enough so it can do it's job.  Looks like this has been manually
done in the past, so just codifying existing practice.

Also does some puppet-lint cleanups, but not all see commit log if you
are interested
