### PR TITLE
Class to manage ptheartbeat config

### DIFF
--- a/manifests/pt_heartbeat.pp
+++ b/manifests/pt_heartbeat.pp
@@ -1,0 +1,15 @@
+# Install config file needed by scout plugin
+class scout::pt_heartbeat {
+  $monitor_user = hiera('scout::replication_monitoring_user','')
+  $monitor_password = hiera('scout::replication_monitoring_password','')
+  $monitor_database = hiera('scout::replication_monitoring_database','')
+
+  file {'scout-pt-heartbeat-config-file':
+    ensure  => file,
+    require => User[$scout::user],
+    path    => "${scout::home_dir}/.pt-heartbeat.cfg",
+    owner   => $scout::user,
+    mode    => '0400',
+    content => template('scout/heartbeat-config.erb')
+  }
+}

--- a/templates/heartbeat-config.erb
+++ b/templates/heartbeat-config.erb
@@ -1,0 +1,5 @@
+host=localhost
+pass=<%= monitor_password  %>
+user=<%= monitor_user %>
+database=<%= monitor_database %>
+pid=/var/run/pt-heartbeat.pid


### PR DESCRIPTION
This class is supposed to put in place a config file for pt-heartbeat's
use, which is a binary used by a scout plugin to monitor replication lag
