### PR TITLE
Check to make sure we don't redefine packages

### DIFF
--- a/manifests/redis.pp
+++ b/manifests/redis.pp
@@ -5,8 +5,7 @@ class scout::redis {
       ensure    => present,
       provider  => 'gem',
       require   => [
-        Package['ruby'],
-        Package['rubygems'],
+        Package['rubygems']
       ],
     }
   }

--- a/manifests/sidekiq.pp
+++ b/manifests/sidekiq.pp
@@ -8,7 +8,6 @@ class scout::sidekiq (
       ensure    => $version,
       provider  => 'gem',
       require   => [
-        Package['ruby'],
         Package['rubygems'],
       ],
     }


### PR DESCRIPTION
redis and sidekiq are both packages likely to be defined in other
manifests, make sure that we don't cause a redefinition error
