### PR TITLE
update to non-deprecated ERB template format

### DIFF
--- a/templates/heartbeat-config.erb
+++ b/templates/heartbeat-config.erb
@@ -1,5 +1,5 @@
 host=localhost
-pass=<%= monitor_password  %>
-user=<%= monitor_user %>
-database=<%= monitor_database %>
+pass=<%= @monitor_password  %>
+user=<%= @monitor_user %>
+database=<%= @monitor_database %>
 pid=/var/run/pt-heartbeat.pid


### PR DESCRIPTION
Taking the opportunity for some house keeping while working on puppet for 
dr databases.  This PR updates ERB template in use to non-deprecated '@variable_name' syntax
