### PR TITLE
remove File[/var/lib/puppet].  Does not belong

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -56,13 +56,6 @@ class scout(
     environment => $cron_environment,
   }
 
-  file { '/var/lib/puppet':
-    ensure => directory,
-    owner  => 'puppet',
-    group  => 'puppet',
-    mode   => '0755',
-  }
-
   user { $user:
     ensure     => 'present',
     managehome => true,


### PR DESCRIPTION
This is not the place for references to our /var/lib/puppet perms.  Remove here.  Will enforce this configuration from within envato/marketplace-puppet