### PR TITLE
Extract class to manage Puppet state directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,14 @@ node foo.example.com {
     scout_environment_name => 'production',
     manage_ruby            => true,
   }
+
+  # Using Scout to monitor Puppet? Ensure Scout can read the state:
+  class { 'scout::manage_puppet_state_dir':
+    group  => 'puppet',
+    mode   => '0755',
+    owner  => 'puppet',
+    path   => '/var/lib/puppet',
+  }
 }
 ```
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -56,13 +56,6 @@ class scout(
     environment => $cron_environment,
   }
 
-  file { '/var/lib/puppet':
-    ensure => directory,
-    owner  => 'puppet',
-    group  => 'puppet',
-    mode   => '0755',
-  }
-
   user { $user:
     ensure     => 'present',
     managehome => true,

--- a/manifests/manage_puppet_state_dir.pp
+++ b/manifests/manage_puppet_state_dir.pp
@@ -1,0 +1,39 @@
+# = Class: scout::manage_puppet_state_dir
+#
+# This class manages the Puppet state directory to allow Scout to monitor it.
+#
+# == Parameters:
+#
+# $group::      Group to own the directory. Defaults to 'puppet'.
+# $mode::       Mode for the directory. Defaults to '0755'.
+# $owner::      User to own the directory. Defaults to 'puppet'.
+# $path::       Directory to manage. Defaults to '/var/lib/puppet'.
+#
+# == Requires:
+#
+# Nothing.
+#
+# == Sample Usage:
+#
+#   class { 'scout::manage_puppet_state_dir':
+#     group  => 'puppet',
+#     mode   => '0755',
+#     owner  => 'puppet',
+#     path   => '/var/lib/puppet',
+#   }
+#
+class scout::manage_puppet_state_dir (
+  $group = hiera('scout::manage_puppet_state_dir::group', 'puppet'),
+  $mode = hiera('scout::manage_puppet_state_dir::mode', '0755'),
+  $owner = hiera('scout::manage_puppet_state_dir::owner', 'puppet'),
+  $path = hiera('scout::manage_puppet_state_dir::path', '/var/lib/puppet'),
+) {
+
+  file {"scout::manage_puppet_state_dir: ${path}":
+    ensure => directory,
+    group  => $group,
+    mode   => $mode,
+    owner  => $owner,
+    path   => $path,
+  }
+}


### PR DESCRIPTION
...to allow Scout to monitor it. See https://github.com/envato/puppet-scout/commit/2ab8ca061a49d47a254201f107b274698e4df94d for the intent.

Alternative approach to https://github.com/envato/puppet-scout/pull/18 making this optional (see documentation for usage).

Cc: @andrewjhumphrey & @sevaine