### PR TITLE
Update the scout user

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ group :test do
   gem "puppet", ENV['PUPPET_VERSION'] || '~> 3.7.0'
   gem "rspec-puppet", :git => 'https://github.com/rodjek/rspec-puppet.git'
   gem "puppetlabs_spec_helper"
+  gem "puppet-lint", '1.0.1'
 end
 
 group :development do

--- a/Modulefile
+++ b/Modulefile
@@ -1,5 +1,5 @@
 name    'puppet-scout'
-version '1.0.8'
+version '2.0.0'
 source 'https://github.com/envato/puppet-scout'
 author 'Envato'
 license 'MIT License (MIT)'

--- a/README.md
+++ b/README.md
@@ -40,3 +40,9 @@ node foo.example.com {
 It is important to note: If you do not have a corresponding environment set up
 correctly in the scout dashboard, the `scout_environment_name` will not have any
 effect.
+
+ChangeLog:
+v2.0.0:
+  * includes the any2array function from puppetlabs-stdlib in version 4.6.0
+  * moved rescourses into their own classes
+  * added the ability to include a groups for scout (and manage scout gid).

--- a/manifests/cron.pp
+++ b/manifests/cron.pp
@@ -1,3 +1,4 @@
+# installs cron
 class scout::cron (
   $ensure                 = 'present',
   $user                   = scout,

--- a/manifests/cron.pp
+++ b/manifests/cron.pp
@@ -5,11 +5,15 @@ class scout::cron (
   $scout_environment_name = undef,
   $cron_environment       = undef
   ) {
+
+  if $cron_environment {
+    Cron['scout'] { environment => $cron_environment }
+  }
+
   cron { 'scout':
     ensure      => $ensure,
     user        => $user,
     command     => "/usr/bin/env scout ${scout_key} -e ${scout_environment_name}",
-    environment => ${cron_environment},
     require     => User[$user],
   }
 }

--- a/manifests/cron.pp
+++ b/manifests/cron.pp
@@ -3,13 +3,13 @@ class scout::cron (
   $user                   = scout,
   $scout_key              = undef,
   $scout_environment_name = undef,
-  $environment            = undef
+  $cron_environment       = undef
   ) {
   cron { 'scout':
     ensure      => $ensure,
-    require     => User[$user],
     user        => $user,
     command     => "/usr/bin/env scout ${scout_key} -e ${scout_environment_name}",
-    environment => $cron_environment,
+    environment => ${cron_environment},
+    require     => User[$user],
   }
 }

--- a/manifests/cron.pp
+++ b/manifests/cron.pp
@@ -1,0 +1,15 @@
+class scout::cron (
+  $ensure                 = 'present',
+  $user                   = scout,
+  $scout_key              = undef,
+  $scout_environment_name = undef,
+  $environment            = undef
+  ) {
+  cron { 'scout':
+    ensure      => $ensure,
+    require     => User[$user],
+    user        => $user,
+    command     => "/usr/bin/env scout ${scout_key} -e ${scout_environment_name}",
+    environment => $cron_environment,
+  }
+}

--- a/manifests/cron.pp
+++ b/manifests/cron.pp
@@ -12,9 +12,9 @@ class scout::cron (
   }
 
   cron { 'scout':
-    ensure      => $ensure,
-    user        => $user,
-    command     => "/usr/bin/env scout ${scout_key} -e ${scout_environment_name}",
-    require     => User[$user],
+    ensure  => $ensure,
+    user    => $user,
+    command => "/usr/bin/env scout ${scout_key} -e ${scout_environment_name}",
+    require => User[$user],
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,7 +6,7 @@ class scout(
   $group                  = 'scout',
   $groups                 = undef,
   $cron_environment       = undef,
-  $homedir                = '/home/scout',
+  $home_dir               = '/home/scout',
   $managehome             = true,
   $public_cert            = undef,
   $scout_environment_name = 'production',
@@ -22,14 +22,14 @@ class scout(
   class { 'scout::user':
     ensure     => $ensure,
     user       => $user,
-    homedir    => $homedir,
+    homedir    => $home_dir,
     group      => $group,
     groups     => $groups,
     managehome => $managehome,
   }
 
   if $public_cert {
-    $scout_cert_path = "${homedir}/.scout"
+    $scout_cert_path = "${home_dir}/.scout"
 
     file { $scout_cert_path:
       ensure  => $dir_ensure,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -38,7 +38,7 @@ class scout(
     }
 
     file { "${scout_cert_path}/scout_rsa.pub":
-      ensure  => $ensure
+      ensure  => $ensure,
       content => $public_cert,
       owner   => $user,
       require => [

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -58,13 +58,13 @@ class scout(
     include scout::ruby
   }
 
-  class { 'scout::package': ensure => 'latest' }
+  class { 'scout::install': ensure => 'latest' }
 
   class { 'scout::cron':
     ensure                 => $ensure,
     user                   => $user,
     scout_key              => $scout_key,
     scout_environment_name => $scout_environment_name,
-    environment            => $cron_environment
+    cron_environment       => $cron_environment
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,30 +1,42 @@
 # Manages scoutapp.com agent
 class scout(
+  $ensure           = 'present',
   $scout_key        = undef,
   $user             = 'scout',
   $cron_environment = undef,
-  $home_dir         = '',
+  $homedir          = '/home/scout',
+  $managehome       = true,
   $public_cert      = undef,
   $scout_environment_name = 'production',
   $manage_ruby      = false,
 ) {
 
-  if $home_dir == '' and $user != '' {
-    $valid_home_dir="/home/${user}"
+  if $ensure == 'present' {
+    $dir_ensure = 'directory'
   } else {
-    $valid_home_dir=$home_dir
+    $dir_ensure = 'absent'
+  }
+
+  class { 'scout::user':
+    ensure => $ensure,
+    user   => $user,
+    homedir => $homedir,
+    group   => $group,
+    groups  => $groups,
+    managehome => $managehome,
   }
 
   if $public_cert {
     $scout_cert_path = "${valid_home_dir}/.scout"
 
     file { $scout_cert_path:
-      ensure  => directory,
+      ensure  => $dir_ensure,
       owner   => $user,
       require => User[$user],
     }
 
     file { "${scout_cert_path}/scout_rsa.pub":
+      ensure  => $ensure
       content => $public_cert,
       owner   => $user,
       require => [
@@ -34,7 +46,7 @@ class scout(
     }
   }
 
-  if $manage_ruby == true {
+  if $manage_ruby {
     Package['scout'] {
       require  => [
         Package['ruby'],
@@ -44,21 +56,13 @@ class scout(
     include scout::ruby
   }
 
-  package { 'scout':
-    ensure   => 'latest',
-    provider => 'gem',
-  }
+  class { 'scout::package': ensure => 'latest' }
 
-  cron { 'scout':
-    require     => User[$user],
-    user        => $user,
-    command     => "/usr/bin/env scout ${scout_key} -e ${scout_environment_name}",
-    environment => $cron_environment,
-  }
-
-  user { $user:
-    ensure     => 'present',
-    managehome => true,
-    home       => $valid_home_dir,
+  class { 'scout::cron':
+    ensure            => $ensure,
+    user              => $user,
+    scout_key         => $scout_key,
+    scout_environment => $scout_environment,
+    environment       => $cron_environment
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,14 +1,16 @@
 # Manages scoutapp.com agent
 class scout(
-  $ensure           = 'present',
-  $scout_key        = undef,
-  $user             = 'scout',
-  $cron_environment = undef,
-  $homedir          = '/home/scout',
-  $managehome       = true,
-  $public_cert      = undef,
+  $ensure                 = 'present',
+  $scout_key              = undef,
+  $user                   = 'scout',
+  $group                  = 'scout',
+  $groups                 = undef,
+  $cron_environment       = undef,
+  $homedir                = '/home/scout',
+  $managehome             = true,
+  $public_cert            = undef,
   $scout_environment_name = 'production',
-  $manage_ruby      = false,
+  $manage_ruby            = false,
 ) {
 
   if $ensure == 'present' {
@@ -18,16 +20,16 @@ class scout(
   }
 
   class { 'scout::user':
-    ensure => $ensure,
-    user   => $user,
-    homedir => $homedir,
-    group   => $group,
-    groups  => $groups,
+    ensure     => $ensure,
+    user       => $user,
+    homedir    => $homedir,
+    group      => $group,
+    groups     => $groups,
     managehome => $managehome,
   }
 
   if $public_cert {
-    $scout_cert_path = "${valid_home_dir}/.scout"
+    $scout_cert_path = "${homedir}/.scout"
 
     file { $scout_cert_path:
       ensure  => $dir_ensure,
@@ -59,10 +61,10 @@ class scout(
   class { 'scout::package': ensure => 'latest' }
 
   class { 'scout::cron':
-    ensure            => $ensure,
-    user              => $user,
-    scout_key         => $scout_key,
-    scout_environment => $scout_environment,
-    environment       => $cron_environment
+    ensure                 => $ensure,
+    user                   => $user,
+    scout_key              => $scout_key,
+    scout_environment_name => $scout_environment_name,
+    environment            => $cron_environment
   }
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,7 +1,8 @@
+# installs scout gem
 class scout::install (
-  $ensure  => 'latest',
+  $ensure  = 'latest',
   ) {
-  
+
   package { 'scout':
     ensure   => $ensure,
     provider => 'gem',

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,0 +1,9 @@
+class scout::package (
+  $ensure  => 'latest',
+  ) {
+  
+  package { 'scout':
+    ensure   => $ensure,
+    provider => 'gem',
+  }
+}

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,4 +1,4 @@
-class scout::package (
+class scout::install (
   $ensure  => 'latest',
   ) {
   

--- a/manifests/ruby.pp
+++ b/manifests/ruby.pp
@@ -1,6 +1,6 @@
 # Install `ruby` and `rubygems` for Scout
 class scout::ruby {
-    
+
   package { 'ruby':
     ensure  => present,
   }

--- a/manifests/user.pp
+++ b/manifests/user.pp
@@ -1,3 +1,4 @@
+# add scout user and groups
 class scout::user (
   $ensure    = 'present',
   $user      = 'scout',
@@ -16,7 +17,7 @@ class scout::user (
   if is_array($groups) {
     User[$user] { groups => $groups }
   } else {
-    User[$user] { groups = any2array($groups)
+    User[$user] { groups => any2array($groups) }
   }
 
   user { $user:

--- a/manifests/user.pp
+++ b/manifests/user.pp
@@ -1,0 +1,28 @@
+class scout::user (
+  $ensure    = 'present',
+  $user      = 'scout',
+  $homedir   = '/home/scout',
+  group      = 'scout',
+  managehome = true,
+  groups     = undef
+  ) {
+
+  validate_absolute_path($homedir)
+
+  group { $group:
+    ensure => $ensure,
+  }
+
+  if is_array($groups) {
+    User[$user] { groups => $groups }
+  } else {
+    User[$user] { groups = any2array($groups)
+  }
+
+  user { $user:
+    group      => $group,
+    home       => $homedir,
+    managehome => $managehome,
+    require    => Group[$group],
+  }
+}

--- a/manifests/user.pp
+++ b/manifests/user.pp
@@ -2,9 +2,9 @@ class scout::user (
   $ensure    = 'present',
   $user      = 'scout',
   $homedir   = '/home/scout',
-  group      = 'scout',
-  managehome = true,
-  groups     = undef
+  $group      = 'scout',
+  $managehome = true,
+  $groups     = undef
   ) {
 
   validate_absolute_path($homedir)

--- a/manifests/user.pp
+++ b/manifests/user.pp
@@ -5,7 +5,7 @@ class scout::user (
   $homedir   = '/home/scout',
   $group      = 'scout',
   $managehome = true,
-  $groups     = undef
+  $groups     = []
   ) {
 
   validate_absolute_path($homedir)
@@ -21,7 +21,7 @@ class scout::user (
   }
 
   user { $user:
-    group      => $group,
+    gid        => $group,
     home       => $homedir,
     managehome => $managehome,
     require    => Group[$group],

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppet-scout",
-  "version": "1.0.7",
+  "version": "2.0.0",
   "author": "Envato",
   "summary": "Installs and configures scout",
   "license": "MIT",
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs-stdlib",
-      "version_requirement": "1.0.0"
+      "version_requirement": ">=4.6.0 <5.0.0"
     }
   ]
 }


### PR DESCRIPTION
Context
---
We don't have the ability to grant groups to the scout user. This allows us to grant different groups to scout to read certain log files.   

Change
---
Adding the ability to define groups for the scout user.

Took the opportunity to separate out the resources into their own classes.

Puppet-Lint has a bug that ignores excluded directories - downgrading and pinning to a good version.
