### PR TITLE
Fix gem install

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,0 +1,3 @@
+fixtures:
+  symlinks:
+    scout: "#{source_dir}"

--- a/.hiera_rspec.yaml
+++ b/.hiera_rspec.yaml
@@ -1,0 +1,8 @@
+---
+:backends:
+  - yaml
+:yaml:
+  :datadir: spec/hieradata
+:hierarchy:
+  - common
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,18 +11,13 @@ script: bundle exec rake test --trace
 env:
   - PUPPET_VERSION="~> 3.4.0"
   - PUPPET_VERSION="~> 3.5.0" STRICT_VARIABLES=yes
-  - PUPPET_VERSION="~> 3.6.0" STRICT_VARIABLES=yes
   - PUPPET_VERSION="~> 3.8.0" STRICT_VARIABLES=yes
 matrix:
   exclude:
   - rvm: 1.9.3
-    env: PUPPET_VERSION="~> 3.4.0"
-  - rvm: 1.9.3
-    env: PUPPET_VERSION="~> 3.8.0" STRICT_VARIABLES=yes
+    env: PUPPET_VERSION="~> 3.3.0"
   - rvm: 2.1.0
-    env: PUPPET_VERSION="~> 3.4.0"
+    env: PUPPET_VERSION="~> 3.3.0"
   - rvm: 2.2.0
-    env: PUPPET_VERSION="~> 3.4.0"
-  - rvm: 2.2.0
-    env: PUPPET_VERSION="~> 3.8.0" STRICT_VARIABLES=yes
+    env: PUPPET_VERSION="~> 3.6.0"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,13 @@ rvm:
   - 1.9.3
   - 2.0.0
   - 2.1.0
+  - 2.2.0
 script: bundle exec rake test --trace
 env:
   - PUPPET_VERSION="~> 2.7.0"
-  - PUPPET_VERSION="~> 3.2.0" STRICT_VARIABLES=yes
-  - PUPPET_VERSION="~> 3.3.0" STRICT_VARIABLES=yes
-  - PUPPET_VERSION="~> 3.4.0" STRICT_VARIABLES=yes
+  - PUPPET_VERSION="~> 3.2.0"
+  - PUPPET_VERSION="~> 3.3.0"
+  - PUPPET_VERSION="~> 3.4.0"
   - PUPPET_VERSION="~> 3.5.0" STRICT_VARIABLES=yes
   - PUPPET_VERSION="~> 3.6.0" STRICT_VARIABLES=yes
 matrix:
@@ -24,8 +25,10 @@ matrix:
   - rvm: 2.1.0
     env: PUPPET_VERSION="~> 2.7.0"
   - rvm: 2.1.0
-    env: PUPPET_VERSION="~> 3.2.0" STRICT_VARIABLES=yes
+    env: PUPPET_VERSION="~> 3.2.0"
   - rvm: 2.1.0
-    env: PUPPET_VERSION="~> 3.3.0" STRICT_VARIABLES=yes
+    env: PUPPET_VERSION="~> 3.3.0"
   - rvm: 2.1.0
-    env: PUPPET_VERSION="~> 3.4.0" STRICT_VARIABLES=yes
+    env: PUPPET_VERSION="~> 3.4.0"
+  - rvm: 2.2.0
+    env: PUPPET_VERSION="~> 3.8.0" STRICT_VARIABLES=yes

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,32 +3,26 @@ language: ruby
 bundler_args: --without development
 before_install: rm Gemfile.lock || true
 rvm:
-  - 1.8.7
   - 1.9.3
   - 2.0.0
   - 2.1.0
   - 2.2.0
 script: bundle exec rake test --trace
 env:
-  - PUPPET_VERSION="~> 2.7.0"
-  - PUPPET_VERSION="~> 3.2.0"
-  - PUPPET_VERSION="~> 3.3.0"
   - PUPPET_VERSION="~> 3.4.0"
   - PUPPET_VERSION="~> 3.5.0" STRICT_VARIABLES=yes
   - PUPPET_VERSION="~> 3.6.0" STRICT_VARIABLES=yes
+  - PUPPET_VERSION="~> 3.8.0" STRICT_VARIABLES=yes
 matrix:
   exclude:
   - rvm: 1.9.3
-    env: PUPPET_VERSION="~> 2.7.0"
-  - rvm: 2.0.0
-    env: PUPPET_VERSION="~> 2.7.0"
-  - rvm: 2.1.0
-    env: PUPPET_VERSION="~> 2.7.0"
-  - rvm: 2.1.0
-    env: PUPPET_VERSION="~> 3.2.0"
-  - rvm: 2.1.0
-    env: PUPPET_VERSION="~> 3.3.0"
+    env: PUPPET_VERSION="~> 3.4.0"
+  - rvm: 1.9.3
+    env: PUPPET_VERSION="~> 3.8.0" STRICT_VARIABLES=yes
   - rvm: 2.1.0
     env: PUPPET_VERSION="~> 3.4.0"
   - rvm: 2.2.0
+    env: PUPPET_VERSION="~> 3.4.0"
+  - rvm: 2.2.0
     env: PUPPET_VERSION="~> 3.8.0" STRICT_VARIABLES=yes
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ rvm:
   - 1.9.3
   - 2.0.0
   - 2.1.0
-  - 2.2.0
 script: bundle exec rake test --trace
 env:
   - PUPPET_VERSION="~> 3.4.0"
@@ -18,7 +17,3 @@ matrix:
     env: PUPPET_VERSION="~> 3.3.0"
   - rvm: 2.1.0
     env: PUPPET_VERSION="~> 3.3.0"
-  - rvm: 2.2.0
-    env: PUPPET_VERSION="~> 3.4.0"
-  - rvm: 2.2.0
-    env: PUPPET_VERSION="~> 3.5.0" STRICT_VARIABLES=yes

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,5 +21,4 @@ matrix:
   - rvm: 2.2.0
     env: PUPPET_VERSION="~> 3.4.0"
   - rvm: 2.2.0
-    env: PUPPET_VERSION="~> 3.5.0"
-
+    env: PUPPET_VERSION="~> 3.5.0" STRICT_VARIABLES=yes

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,5 +19,7 @@ matrix:
   - rvm: 2.1.0
     env: PUPPET_VERSION="~> 3.3.0"
   - rvm: 2.2.0
-    env: PUPPET_VERSION="~> 3.6.0"
+    env: PUPPET_VERSION="~> 3.4.0"
+  - rvm: 2.2.0
+    env: PUPPET_VERSION="~> 3.5.0"
 

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ group :test do
   gem "puppet", ENV['PUPPET_VERSION'] || '~> 3.7.0'
   gem "rspec-puppet", :git => 'https://github.com/rodjek/rspec-puppet.git'
   gem "puppetlabs_spec_helper"
-  gem "puppet-lint", '1.0.1'
+  gem "puppet-lint"
 end
 
 group :development do

--- a/Modulefile
+++ b/Modulefile
@@ -1,5 +1,5 @@
 name    'puppet-scout'
-version '2.0.0'
+version '2.0.1'
 source 'https://github.com/envato/puppet-scout'
 author 'Envato'
 license 'MIT License (MIT)'

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -3,7 +3,7 @@ class scout::install (
   $ensure  = 'latest',
   ) {
 
-  package { '^scout$':
+  package { '^scout':
     ensure   => $ensure,
     provider => 'gem',
   }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -3,7 +3,7 @@ class scout::install (
   $ensure  = 'latest',
   ) {
 
-  package { 'scout':
+  package { '^scout$':
     ensure   => $ensure,
     provider => 'gem',
   }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppet-scout",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "author": "Envato",
   "summary": "Installs and configures scout",
   "license": "MIT",

--- a/spec/classes/install_spec.rb
+++ b/spec/classes/install_spec.rb
@@ -7,7 +7,7 @@ describe 'scout::install' do
   end
 
   it 'scout gem is installed' do
-    should contain_package('^scout$').with(
+    should contain_package('^scout').with(
       'ensure' => 'latest',
       'provider' => 'gem'
     )

--- a/spec/classes/install_spec.rb
+++ b/spec/classes/install_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+describe 'scout::install' do
+
+  it 'should compile' do
+    should contain_class('scout::install')
+  end
+
+  it 'scout gem is installed' do
+    should contain_package('^scout$').with(
+      'ensure' => 'latest',
+      'provider' => 'gem'
+    )
+  end
+end

--- a/spec/hieradata/common.yaml
+++ b/spec/hieradata/common.yaml
@@ -1,0 +1,3 @@
+scout::install::version: latest
+scout::key: 'somekey'
+

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,17 +1,22 @@
 dir = File.expand_path(File.dirname(__FILE__))
 $LOAD_PATH.unshift File.join(dir, 'lib')
 
-require 'mocha'
-require 'puppet'
-require 'rspec'
-require 'spec/autorun'
+require 'puppetlabs_spec_helper/module_spec_helper'
 
-Spec::Runner.configure do |config|
-    config.mock_with :mocha
-end
+RSpec.configure do |c|
 
-# We need this because the RAL uses 'should' as a method.  This
-# allows us the same behaviour but with a different method name.
-class Object
-    alias :must :should
+  c.before :each do
+    # Ensure that we don't accidentally cache facts and environment
+    # between test cases.
+    Facter::Util::Loader.any_instance.stubs(:load_all)
+    Facter.clear
+    Facter.clear_messages
+
+    # Store any environment variables away to be restored later
+    @old_env = {}
+    ENV.each_key { |k| @old_env[k] = ENV[k] }
+
+    Puppet.settings[:strict_variables] = true if ENV['STRICT_VARIABLES'] == 'yes'
+  end
+  c.hiera_config = File.join(File.expand_path(File.dirname(__FILE__)), '..', '.hiera_rspec.yaml')
 end


### PR DESCRIPTION
Context:

```
Notice: /Stage[main]/Scout::Install/Package[scout]/ensure: ensure changed '["5.9.8"]' to '1.0.0'
```

Why is that?? Oh looky here:
```
$ /usr/local/rbenv/shims/gem list --remote scout$

*** REMOTE GEMS ***

alephant-scout (1.0.0)
```
That looks familiar...

This message appears because ruby gem is looking up scout and returning the first version on the gem list. 

Change:
Prepend with a `^` to make sure we are properly scoped.