### PR TITLE
this is failing on precise hosts. removing.

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -1,5 +1,5 @@
 name    'puppet-scout'
-version '2.0.2'
+version '2.0.4'
 source 'https://github.com/envato/puppet-scout'
 author 'Envato'
 license 'MIT License (MIT)'

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -3,7 +3,7 @@ class scout::install (
   $ensure  = 'latest',
   ) {
 
-  package { '^scout':
+  package { 'scout':
     ensure   => $ensure,
     provider => 'gem',
   }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppet-scout",
-  "version": "2.0.2",
+  "version": "2.0.4",
   "author": "Envato",
   "summary": "Installs and configures scout",
   "license": "MIT",

--- a/spec/classes/install_spec.rb
+++ b/spec/classes/install_spec.rb
@@ -7,7 +7,7 @@ describe 'scout::install' do
   end
 
   it 'scout gem is installed' do
-    should contain_package('^scout').with(
+    should contain_package('scout').with(
       'ensure' => 'latest',
       'provider' => 'gem'
     )


### PR DESCRIPTION
So now it is producing this error:

```
==> mp_puppet: Error: Could not update: Execution of '/usr/bin/gem install --no-rdoc --no-ri ^scout' returned 2: ERROR:  Could not find a valid gem '^scout' (>= 0) in any repository
==> mp_puppet: ERROR:  Possible alternatives: scout, rscout, escort, scour, scoot
```

If it is installed it is happy, if it is installing it is unhappy :(