### PR TITLE
Last update has broken scout cron environment

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -1,5 +1,5 @@
 name    'puppet-scout'
-version '2.0.6'
+version '2.0.7'
 source 'https://github.com/envato/puppet-scout'
 author 'Envato'
 license 'MIT License (MIT)'

--- a/Modulefile
+++ b/Modulefile
@@ -1,5 +1,5 @@
 name    'puppet-scout'
-version '2.0.4'
+version '2.0.6'
 source 'https://github.com/envato/puppet-scout'
 author 'Envato'
 license 'MIT License (MIT)'

--- a/manifests/cron.pp
+++ b/manifests/cron.pp
@@ -10,7 +10,7 @@ class scout::cron (
   $scout_roles = hiera_array('scout::roles', undef)
 
   if $cron_environment {
-    $environment = join(["SCOUT_KEY=${scout_key}", "\n", $cron_environment])
+    $environment = join(["SCOUT_KEY=${scout_key}", $cron_environment], "\n")
   }
   else
   {

--- a/manifests/cron.pp
+++ b/manifests/cron.pp
@@ -10,7 +10,7 @@ class scout::cron (
   $scout_roles = hiera_array('scout::roles', undef)
 
   if $cron_environment {
-    $environment = join(["SCOUT_KEY=${scout_key}", '\n', $cron_environment])
+    $environment = join(["SCOUT_KEY=${scout_key}", "\n", $cron_environment])
   }
   else
   {

--- a/manifests/cron.pp
+++ b/manifests/cron.pp
@@ -10,7 +10,7 @@ class scout::cron (
   $scout_roles = hiera_array('scout::roles', undef)
 
   if $cron_environment {
-    $environment = join(["SCOUT_KEY=${scout_key}", $cron_environment], ' ')
+    $environment = join(["SCOUT_KEY=${scout_key}", '\n', $cron_environment])
   }
   else
   {

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppet-scout",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "author": "Envato",
   "summary": "Installs and configures scout",
   "license": "MIT",

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppet-scout",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "author": "Envato",
   "summary": "Installs and configures scout",
   "license": "MIT",

--- a/spec/classes/cron_spec.rb
+++ b/spec/classes/cron_spec.rb
@@ -58,7 +58,7 @@ describe 'scout::cron' do
     it 'adds the key to the cron environment' do
       is_expected.to contain_cron('scout').with(
         'ensure'      => 'present',
-        'environment' => 'SCOUT_KEY=key\nMAILTO=scout-mailbox@my.org',
+        'environment' => "SCOUT_KEY=key\nMAILTO=scout-mailbox@my.org",
         'command'     => '/usr/bin/env scout ${SCOUT_KEY}',
         'user'        => 'scout'
       )

--- a/spec/classes/cron_spec.rb
+++ b/spec/classes/cron_spec.rb
@@ -58,7 +58,7 @@ describe 'scout::cron' do
     it 'adds the key to the cron environment' do
       is_expected.to contain_cron('scout').with(
         'ensure'      => 'present',
-        'environment' => 'SCOUT_KEY=key MAILTO=scout-mailbox@my.org',
+        'environment' => 'SCOUT_KEY=key\nMAILTO=scout-mailbox@my.org',
         'command'     => '/usr/bin/env scout ${SCOUT_KEY}',
         'user'        => 'scout'
       )


### PR DESCRIPTION
The problem is that when we use the join on the environment, puppet interprets the string as one string:

```
SCOUT_KEY=<removed> PATH=/usr/local/rbenv/shims:/usr/local/rbenv/bin:/usr/local/bin:/usr/bin:/bin
```

There need to be a carriage return there otherwise the env isn't set properly.

https://github.com/envato/puppet-scout/pull/24
